### PR TITLE
fix(landing): make mobile header menu full width

### DIFF
--- a/src/components/landing/LandingHeader.spec.tsx
+++ b/src/components/landing/LandingHeader.spec.tsx
@@ -1,0 +1,14 @@
+import assert from "node:assert/strict"
+import { readFileSync } from "node:fs"
+import { resolve } from "node:path"
+import test from "node:test"
+
+test("LandingHeader anchors the mobile menu to the full header width", () => {
+    const source = readFileSync(resolve(process.cwd(), "src/components/landing/LandingHeader.tsx"), "utf-8")
+
+    assert.match(source, /<Collapsible open=\{isOpen\} onOpenChange=\{setIsOpen\}>/)
+    assert.match(source, /className="border-t-\[3px\] border-border bg-cream md:hidden/)
+    assert.match(source, /className="mx-auto w-full max-w-7xl px-4 py-4 md:px-6"/)
+    assert.doesNotMatch(source, /<Collapsible open=\{isOpen\} onOpenChange=\{setIsOpen\} className="relative md:hidden">/)
+    assert.doesNotMatch(source, /className="absolute left-0 top-full w-full/)
+})

--- a/src/components/landing/LandingHeader.tsx
+++ b/src/components/landing/LandingHeader.tsx
@@ -17,57 +17,59 @@ export default function LandingHeader() {
 
     return (
         <header className="sticky top-0 z-50 border-b-[3px] border-border bg-cream">
-            <div className="mx-auto flex h-16 w-full max-w-7xl items-center justify-between gap-4 px-4 md:px-6">
-                <Link to="/" className="font-display text-3xl font-extrabold tracking-[-0.05em]">
-                    JUNTO
-                </Link>
+            <Collapsible open={isOpen} onOpenChange={setIsOpen}>
+                <div className="mx-auto flex h-16 w-full max-w-7xl items-center justify-between gap-4 px-4 md:px-6">
+                    <Link to="/" className="font-display text-3xl font-extrabold tracking-[-0.05em]">
+                        JUNTO
+                    </Link>
 
-                <nav className="hidden items-center gap-1 md:flex">
-                    {landingNavItems.map((item) => (
-                        <a
-                            key={item.label}
-                            href={item.href}
-                            className="border-2 border-transparent px-4 py-2 font-heading text-sm font-bold transition hover:border-border hover:bg-violet-light"
-                        >
-                            {item.label}
-                        </a>
-                    ))}
-                </nav>
+                    <nav className="hidden items-center gap-1 md:flex">
+                        {landingNavItems.map((item) => (
+                            <a
+                                key={item.label}
+                                href={item.href}
+                                className="border-2 border-transparent px-4 py-2 font-heading text-sm font-bold transition hover:border-border hover:bg-violet-light"
+                            >
+                                {item.label}
+                            </a>
+                        ))}
+                    </nav>
 
-                <div className="hidden items-center gap-3 md:flex">
-                    {loggedIn ? (
-                        <>
-                            <BrutalButton asChild tone="cream" className="px-5">
-                                <Link to="/profile">My profile</Link>
-                            </BrutalButton>
-                            <BrutalButton tone="violet" className="px-5" onClick={logout}>
-                                Logout
-                            </BrutalButton>
-                        </>
-                    ) : (
-                        <>
-                            <BrutalButton asChild tone="cream" className="px-5">
-                                <Link to="/login">Log in</Link>
-                            </BrutalButton>
-                            <BrutalButton asChild tone="violet" className="px-5">
-                                <Link to="/register">Sign up</Link>
-                            </BrutalButton>
-                        </>
-                    )}
-                </div>
+                    <div className="hidden items-center gap-3 md:flex">
+                        {loggedIn ? (
+                            <>
+                                <BrutalButton asChild tone="cream" className="px-5">
+                                    <Link to="/profile">My profile</Link>
+                                </BrutalButton>
+                                <BrutalButton tone="violet" className="px-5" onClick={logout}>
+                                    Logout
+                                </BrutalButton>
+                            </>
+                        ) : (
+                            <>
+                                <BrutalButton asChild tone="cream" className="px-5">
+                                    <Link to="/login">Log in</Link>
+                                </BrutalButton>
+                                <BrutalButton asChild tone="violet" className="px-5">
+                                    <Link to="/register">Sign up</Link>
+                                </BrutalButton>
+                            </>
+                        )}
+                    </div>
 
-                <Collapsible open={isOpen} onOpenChange={setIsOpen} className="relative md:hidden">
                     <BrutalButton
                         type="button"
                         tone="cream"
                         size="icon"
                         aria-label="Toggle menu"
-                        className="h-11 w-11 px-0"
+                        className="h-11 w-11 px-0 md:hidden"
                         onClick={() => setIsOpen((open) => !open)}
                     >
                         {isOpen ? <X /> : <Menu />}
                     </BrutalButton>
-                    <CollapsibleContent className="absolute left-0 top-full w-full border-b-[3px] border-border bg-cream px-4 py-4 data-[state=closed]:animate-out data-[state=open]:animate-in data-[state=open]:slide-in-from-top-2">
+                </div>
+                <CollapsibleContent className="border-t-[3px] border-border bg-cream md:hidden data-[state=closed]:animate-out data-[state=open]:animate-in data-[state=open]:slide-in-from-top-2">
+                    <div className="mx-auto w-full max-w-7xl px-4 py-4 md:px-6">
                         <nav className="flex flex-col gap-2">
                             {landingNavItems.map((item) => (
                                 <a
@@ -85,7 +87,14 @@ export default function LandingHeader() {
                                         <BrutalButton asChild tone="cream" className="w-full">
                                             <Link to="/profile" onClick={() => setIsOpen(false)}>My profile</Link>
                                         </BrutalButton>
-                                        <BrutalButton tone="violet" className="w-full" onClick={logout}>
+                                        <BrutalButton
+                                            tone="violet"
+                                            className="w-full"
+                                            onClick={() => {
+                                                setIsOpen(false)
+                                                logout()
+                                            }}
+                                        >
                                             Logout
                                         </BrutalButton>
                                     </>
@@ -101,9 +110,9 @@ export default function LandingHeader() {
                                 )}
                             </div>
                         </nav>
-                    </CollapsibleContent>
-                </Collapsible>
-            </div>
+                    </div>
+                </CollapsibleContent>
+            </Collapsible>
         </header>
     )
 }


### PR DESCRIPTION
## Summary
- make the landing mobile menu span the full header/container width instead of the hamburger button width
- keep the existing dropdown interaction while ensuring mobile logout also closes the menu
- add a regression spec covering the full-width mobile menu structure

## Testing
- npm run lint:fix
- npm test