### PR TITLE
[codex] Refactor event API loaders into domain hooks

### DIFF
--- a/src/components/discover/NearMeModal.tsx
+++ b/src/components/discover/NearMeModal.tsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense, useEffect, useState, type ComponentType } from "react"
+import { lazy, Suspense, useState, type ComponentType } from "react"
 import BrutalButton from "@/components/ui/brutal-button"
 import {
     Dialog,
@@ -8,8 +8,8 @@ import {
     DialogTitle,
 } from "@/components/ui/dialog"
 import { Input } from "@/components/ui/input"
-import { fetchDiscoverNearbyEvents } from "@/requests/discover"
-import type { DiscoverEvent, DiscoverLocation } from "@/types/discover"
+import { useNearbyDiscoverEvents } from "@/hooks/event/useNearbyDiscoverEvents"
+import type { DiscoverLocation } from "@/types/discover"
 import {
     formatDiscoverDate,
     getDiscoverEventPosition,
@@ -37,60 +37,32 @@ export default function NearMeModal({
     const ResolvedMapComponent = MapComponent ?? LazyMapWithGeocoder
     const [radius, setRadius] = useState(3)
     const [selectedLocation, setSelectedLocation] = useState<DiscoverLocation>()
-    const [events, setEvents] = useState<DiscoverEvent[]>([])
-    const [loading, setLoading] = useState(false)
     const [geoLoading, setGeoLoading] = useState(false)
-    const [error, setError] = useState<string | null>(null)
-
-    useEffect(() => {
-        if (!open || !selectedLocation) {
-            return
-        }
-
-        const currentLocation = selectedLocation
-        let ignore = false
-
-        async function loadNearbyEvents() {
-            setLoading(true)
-            setError(null)
-
-            try {
-                const response = await fetchDiscoverNearbyEvents({
-                    lat: currentLocation.coordinates.lat,
-                    lng: currentLocation.coordinates.lng,
-                    radius,
-                })
-
-                if (!ignore) {
-                    setEvents(response)
-                }
-            } catch (nextError) {
-                if (!ignore) {
-                    setError(nextError instanceof Error ? nextError.message : "Failed to load nearby events")
-                    setEvents([])
-                }
-            } finally {
-                if (!ignore) {
-                    setLoading(false)
-                }
+    const [locationError, setLocationError] = useState<string | null>(null)
+    const {
+        data: events,
+        loading,
+        error: nearbyError,
+    } = useNearbyDiscoverEvents({
+        enabled: open,
+        query: selectedLocation
+            ? {
+                lat: selectedLocation.coordinates.lat,
+                lng: selectedLocation.coordinates.lng,
+                radius,
             }
-        }
-
-        loadNearbyEvents()
-
-        return () => {
-            ignore = true
-        }
-    }, [open, radius, selectedLocation])
+            : undefined,
+    })
+    const error = locationError ?? nearbyError
 
     function handleUseMyLocation() {
         if (!navigator.geolocation) {
-            setError("Geolocation is not supported in this browser.")
+            setLocationError("Geolocation is not supported in this browser.")
             return
         }
 
         setGeoLoading(true)
-        setError(null)
+        setLocationError(null)
 
         navigator.geolocation.getCurrentPosition(
             (position) => {
@@ -105,7 +77,7 @@ export default function NearMeModal({
             },
             () => {
                 setGeoLoading(false)
-                setError("We couldn't access your location. Search for a place instead.")
+                setLocationError("We couldn't access your location. Search for a place instead.")
             },
         )
     }

--- a/src/components/landing/FeaturedEventsSection.tsx
+++ b/src/components/landing/FeaturedEventsSection.tsx
@@ -1,4 +1,3 @@
-import { useEffect, useState } from "react"
 import { Link } from "react-router"
 import SectionHeading from "@/components/landing/SectionHeading"
 import PillBadge from "@/components/ui/pill-badge"
@@ -9,29 +8,12 @@ import {
     getDiscoverCategoryTitles,
     getDiscoverTypeTitle,
 } from "@/components/discover/discover-utils"
-import { fetchLandingUpcomingEvents } from "@/requests/landing"
+import { useLandingUpcomingEvents } from "@/hooks/event/useLandingUpcomingEvents"
 import type { DiscoverEvent } from "@/types/discover"
 import { testIds } from "@/testIds"
 
 export default function FeaturedEventsSection() {
-    const [events, setEvents] = useState<DiscoverEvent[]>([])
-    const [loading, setLoading] = useState(true)
-    const [error, setError] = useState<string | null>(null)
-
-    useEffect(() => {
-        let ignore = false
-
-        loadUpcomingEvents({
-            isCurrent: () => !ignore,
-            onErrorChange: setError,
-            onEventsLoaded: setEvents,
-            onLoadingChange: setLoading,
-        })
-
-        return () => {
-            ignore = true
-        }
-    }, [])
+    const { data: events, loading, error } = useLandingUpcomingEvents()
 
     return (
         <section id="discover" className="px-4 py-14 md:px-6">
@@ -46,37 +28,6 @@ export default function FeaturedEventsSection() {
             </div>
         </section>
     )
-}
-
-async function loadUpcomingEvents({
-    isCurrent,
-    onErrorChange,
-    onEventsLoaded,
-    onLoadingChange,
-}: {
-    isCurrent: () => boolean
-    onErrorChange: (error: string | null) => void
-    onEventsLoaded: (events: DiscoverEvent[]) => void
-    onLoadingChange: (loading: boolean) => void
-}) {
-    onLoadingChange(true)
-    onErrorChange(null)
-
-    try {
-        const response = await fetchLandingUpcomingEvents()
-        if (isCurrent()) {
-            onEventsLoaded(response)
-        }
-    } catch (nextError) {
-        if (isCurrent()) {
-            onErrorChange(nextError instanceof Error ? nextError.message : "Failed to load upcoming events")
-            onEventsLoaded([])
-        }
-    } finally {
-        if (isCurrent()) {
-            onLoadingChange(false)
-        }
-    }
 }
 
 function renderContent({

--- a/src/hooks/event/useDiscoverData.spec.tsx
+++ b/src/hooks/event/useDiscoverData.spec.tsx
@@ -1,0 +1,184 @@
+import assert from "node:assert/strict"
+import test, { type TestContext } from "node:test"
+import { renderHook, waitFor } from "@testing-library/react"
+import { api } from "@/lib/axios"
+import { useDiscoverEvents } from "@/hooks/event/useDiscoverEvents"
+import { useLandingUpcomingEvents } from "@/hooks/event/useLandingUpcomingEvents"
+import { useNearbyDiscoverEvents } from "@/hooks/event/useNearbyDiscoverEvents"
+import { createDiscoverEvent } from "@/test/fixtures"
+
+type Deferred<T> = {
+    promise: Promise<T>
+    reject: (reason?: unknown) => void
+    resolve: (value: T) => void
+}
+
+function createDeferred<T>(): Deferred<T> {
+    let resolve!: (value: T) => void
+    let reject!: (reason?: unknown) => void
+    const promise = new Promise<T>((promiseResolve, promiseReject) => {
+        resolve = promiseResolve
+        reject = promiseReject
+    })
+
+    return { promise, reject, resolve }
+}
+
+function createApiResponse(events = [createDiscoverEvent()]) {
+    return {
+        status: 200,
+        data: {
+            success: true,
+            data: events,
+        },
+    }
+}
+
+test("useDiscoverEvents loads event data for the provided query", async (t: TestContext) => {
+    const event = createDiscoverEvent({ _id: "query-event" })
+    let capturedParams: unknown
+
+    t.mock.method(api, "get", async (url: string, config?: { params?: unknown }) => {
+        assert.equal(url, "/event")
+        capturedParams = config?.params
+        return createApiResponse([event])
+    })
+
+    const { result } = renderHook(() => useDiscoverEvents({
+        limit: 24,
+        page: 1,
+        search: "picnic",
+        typeId: "meetup",
+        categoryId: "community",
+        dateFilter: "week",
+        sort: "latest",
+    }))
+
+    assert.equal(result.current.loading, true)
+
+    await waitFor(() => {
+        assert.equal(result.current.loading, false)
+    })
+
+    assert.deepEqual(result.current.data, [event])
+    assert.equal(result.current.error, null)
+    assert.deepEqual(capturedParams, {
+        limit: 24,
+        page: 1,
+        search: "picnic",
+        type_eq: "meetup",
+        categories_in: "[community]",
+        date_eq: "this_week",
+        sortByDesc: "date",
+    })
+})
+
+test("useDiscoverEvents returns an empty list and error when loading fails", async (t: TestContext) => {
+    t.mock.method(api, "get", async () => {
+        throw new Error("Request failed")
+    })
+
+    const { result } = renderHook(() => useDiscoverEvents({
+        limit: 24,
+        page: 1,
+        sort: "soonest",
+    }))
+
+    await waitFor(() => {
+        assert.equal(result.current.loading, false)
+    })
+
+    assert.deepEqual(result.current.data, [])
+    assert.equal(result.current.error, "Network error")
+})
+
+test("useDiscoverEvents ignores stale responses after the query changes", async (t: TestContext) => {
+    const firstRequest = createDeferred<ReturnType<typeof createApiResponse>>()
+    const secondRequest = createDeferred<ReturnType<typeof createApiResponse>>()
+    const firstEvent = createDiscoverEvent({ _id: "first-event", title: "First event" })
+    const secondEvent = createDiscoverEvent({ _id: "second-event", title: "Second event" })
+
+    t.mock.method(api, "get", (_url: string, config?: { params?: { search?: string } }) => {
+        if (config?.params?.search === "first") {
+            return firstRequest.promise
+        }
+
+        return secondRequest.promise
+    })
+
+    const { result, rerender } = renderHook(
+        ({ search }) => useDiscoverEvents({
+            limit: 24,
+            page: 1,
+            search,
+            sort: "soonest",
+        }),
+        { initialProps: { search: "first" } },
+    )
+
+    rerender({ search: "second" })
+    secondRequest.resolve(createApiResponse([secondEvent]))
+
+    await waitFor(() => {
+        assert.deepEqual(result.current.data, [secondEvent])
+    })
+
+    firstRequest.resolve(createApiResponse([firstEvent]))
+
+    await waitFor(() => {
+        assert.equal(result.current.loading, false)
+    })
+
+    assert.deepEqual(result.current.data, [secondEvent])
+})
+
+test("useDiscoverEvents ignores responses after unmount", async (t: TestContext) => {
+    const request = createDeferred<ReturnType<typeof createApiResponse>>()
+
+    t.mock.method(api, "get", () => request.promise)
+
+    const { unmount } = renderHook(() => useDiscoverEvents({
+        limit: 24,
+        page: 1,
+        sort: "soonest",
+    }))
+
+    unmount()
+    request.resolve(createApiResponse([createDiscoverEvent({ _id: "after-unmount" })]))
+
+    await request.promise
+})
+
+test("useNearbyDiscoverEvents stays idle without an enabled location query", () => {
+    const { result } = renderHook(() => useNearbyDiscoverEvents({
+        enabled: false,
+        query: undefined,
+    }))
+
+    assert.equal(result.current.loading, false)
+    assert.equal(result.current.error, null)
+    assert.deepEqual(result.current.data, [])
+})
+
+test("useLandingUpcomingEvents loads the landing query", async (t: TestContext) => {
+    let capturedParams: unknown
+
+    t.mock.method(api, "get", async (url: string, config?: { params?: unknown }) => {
+        assert.equal(url, "/event")
+        capturedParams = config?.params
+        return createApiResponse([createDiscoverEvent({ _id: "landing-event" })])
+    })
+
+    const { result } = renderHook(() => useLandingUpcomingEvents())
+
+    await waitFor(() => {
+        assert.equal(result.current.loading, false)
+    })
+
+    assert.equal(result.current.data[0]?._id, "landing-event")
+    assert.deepEqual(capturedParams, {
+        limit: 3,
+        page: 1,
+        sortByAsc: "date",
+    })
+})

--- a/src/hooks/event/useDiscoverEventMetadata.ts
+++ b/src/hooks/event/useDiscoverEventMetadata.ts
@@ -1,0 +1,27 @@
+import { useCallback } from "react"
+import { useAsyncList } from "@/hooks/useAsyncList"
+import { fetchDiscoverCategories, fetchDiscoverEventTypes } from "@/requests/discover"
+import type { DiscoverCategoryOption, DiscoverEventTypeOption } from "@/types/discover"
+
+const emptyDiscoverCategories: DiscoverCategoryOption[] = []
+const emptyDiscoverEventTypes: DiscoverEventTypeOption[] = []
+
+export function useDiscoverEventTypes() {
+    const load = useCallback(() => fetchDiscoverEventTypes(), [])
+
+    return useAsyncList({
+        fallbackErrorMessage: "Failed to load event types",
+        initialData: emptyDiscoverEventTypes,
+        load,
+    })
+}
+
+export function useDiscoverCategories() {
+    const load = useCallback(() => fetchDiscoverCategories(), [])
+
+    return useAsyncList({
+        fallbackErrorMessage: "Failed to load categories",
+        initialData: emptyDiscoverCategories,
+        load,
+    })
+}

--- a/src/hooks/event/useDiscoverEvents.ts
+++ b/src/hooks/event/useDiscoverEvents.ts
@@ -1,0 +1,25 @@
+import { useCallback } from "react"
+import { useAsyncList } from "@/hooks/useAsyncList"
+import { fetchDiscoverEvents } from "@/requests/discover"
+import type { DiscoverEvent, DiscoverEventsQuery } from "@/types/discover"
+
+const emptyDiscoverEvents: DiscoverEvent[] = []
+
+export function useDiscoverEvents(query: DiscoverEventsQuery) {
+    const { categoryId, dateFilter, limit, page, search, sort, typeId } = query
+    const load = useCallback(() => fetchDiscoverEvents({
+        categoryId,
+        dateFilter,
+        limit,
+        page,
+        search,
+        sort,
+        typeId,
+    }), [categoryId, dateFilter, limit, page, search, sort, typeId])
+
+    return useAsyncList({
+        fallbackErrorMessage: "Failed to load events",
+        initialData: emptyDiscoverEvents,
+        load,
+    })
+}

--- a/src/hooks/event/useLandingUpcomingEvents.ts
+++ b/src/hooks/event/useLandingUpcomingEvents.ts
@@ -1,0 +1,16 @@
+import { useCallback } from "react"
+import { useAsyncList } from "@/hooks/useAsyncList"
+import { fetchLandingUpcomingEvents } from "@/requests/landing"
+import type { DiscoverEvent } from "@/types/discover"
+
+const emptyDiscoverEvents: DiscoverEvent[] = []
+
+export function useLandingUpcomingEvents() {
+    const load = useCallback(() => fetchLandingUpcomingEvents(), [])
+
+    return useAsyncList({
+        fallbackErrorMessage: "Failed to load upcoming events",
+        initialData: emptyDiscoverEvents,
+        load,
+    })
+}

--- a/src/hooks/event/useNearbyDiscoverEvents.ts
+++ b/src/hooks/event/useNearbyDiscoverEvents.ts
@@ -1,0 +1,33 @@
+import { useCallback } from "react"
+import { useAsyncList } from "@/hooks/useAsyncList"
+import { fetchDiscoverNearbyEvents } from "@/requests/discover"
+import type { DiscoverEvent, DiscoverGeoSearchQuery } from "@/types/discover"
+
+const emptyDiscoverEvents: DiscoverEvent[] = []
+
+export function useNearbyDiscoverEvents({
+    enabled,
+    query,
+}: {
+    enabled: boolean
+    query?: DiscoverGeoSearchQuery
+}) {
+    const lat = query?.lat
+    const lng = query?.lng
+    const radius = query?.radius
+
+    const load = useCallback(() => {
+        if (lat === undefined || lng === undefined || radius === undefined) {
+            return Promise.resolve(emptyDiscoverEvents)
+        }
+
+        return fetchDiscoverNearbyEvents({ lat, lng, radius })
+    }, [lat, lng, radius])
+
+    return useAsyncList({
+        enabled: enabled && Boolean(query),
+        fallbackErrorMessage: "Failed to load nearby events",
+        initialData: emptyDiscoverEvents,
+        load,
+    })
+}

--- a/src/hooks/useAsyncList.ts
+++ b/src/hooks/useAsyncList.ts
@@ -1,0 +1,68 @@
+import { useEffect, useRef, useState } from "react"
+
+type UseAsyncListOptions<T> = {
+    enabled?: boolean
+    fallbackErrorMessage: string
+    initialData: T[]
+    load: () => Promise<T[]>
+}
+
+type UseAsyncListResult<T> = {
+    data: T[]
+    loading: boolean
+    error: string | null
+}
+
+export function useAsyncList<T>({
+    enabled = true,
+    fallbackErrorMessage,
+    initialData,
+    load,
+}: UseAsyncListOptions<T>): UseAsyncListResult<T> {
+    const [data, setData] = useState<T[]>(initialData)
+    const [loading, setLoading] = useState(enabled)
+    const [error, setError] = useState<string | null>(null)
+    const requestIdRef = useRef(0)
+
+    useEffect(() => {
+        requestIdRef.current += 1
+        const requestId = requestIdRef.current
+        let active = true
+
+        if (!enabled) {
+            setLoading(false)
+            setError(null)
+            setData(initialData)
+            return () => {
+                active = false
+            }
+        }
+
+        setLoading(true)
+        setError(null)
+
+        load()
+            .then((response) => {
+                if (active && requestIdRef.current === requestId) {
+                    setData(response)
+                }
+            })
+            .catch((nextError: unknown) => {
+                if (active && requestIdRef.current === requestId) {
+                    setError(nextError instanceof Error ? nextError.message : fallbackErrorMessage)
+                    setData(initialData)
+                }
+            })
+            .finally(() => {
+                if (active && requestIdRef.current === requestId) {
+                    setLoading(false)
+                }
+            })
+
+        return () => {
+            active = false
+        }
+    }, [enabled, fallbackErrorMessage, initialData, load])
+
+    return { data, loading, error }
+}

--- a/src/pages/Events.tsx
+++ b/src/pages/Events.tsx
@@ -145,7 +145,7 @@ function Events() {
             )
             const targetCard = scrollDirectionRef.current === "up"
                 ? visibleCards[0]
-                : downwardCandidates[downwardCandidates.length - 1]
+                : downwardCandidates.at(-1)
 
             if (!targetCard) {
                 return

--- a/src/pages/Events.tsx
+++ b/src/pages/Events.tsx
@@ -1,4 +1,4 @@
-import { startTransition, useDeferredValue, useEffect, useRef, useState } from "react"
+import { useDeferredValue, useEffect, useRef, useState } from "react"
 import { useSearchParams } from "react-router"
 import DiscoverEventCard from "@/components/discover/DiscoverEventCard"
 import DiscoverFilterBar from "@/components/discover/DiscoverFilterBar"
@@ -9,13 +9,11 @@ import {
     getDiscoverCategoryTitleById,
     getDiscoverTypeTitle,
 } from "@/components/discover/discover-utils"
-import { fetchDiscoverCategories, fetchDiscoverEvents, fetchDiscoverEventTypes } from "@/requests/discover"
+import { useDiscoverCategories, useDiscoverEventTypes } from "@/hooks/event/useDiscoverEventMetadata"
+import { useDiscoverEvents } from "@/hooks/event/useDiscoverEvents"
 import type {
     DiscoverActiveFilter,
-    DiscoverCategoryOption,
     DiscoverDateFilter,
-    DiscoverEvent,
-    DiscoverEventTypeOption,
     DiscoverFilters,
 } from "@/types/discover"
 import { testIds } from "@/testIds"
@@ -44,17 +42,27 @@ function Events() {
         ...defaultFilters,
         search: searchParams.get("search") ?? defaultFilters.search,
     })
-    const [events, setEvents] = useState<DiscoverEvent[]>([])
-    const [categories, setCategories] = useState<DiscoverCategoryOption[]>([])
-    const [eventTypes, setEventTypes] = useState<DiscoverEventTypeOption[]>([])
-    const [loading, setLoading] = useState(true)
-    const [error, setError] = useState<string | null>(null)
     const [isNearMeOpen, setIsNearMeOpen] = useState(false)
     const eventCardRefs = useRef<Map<string, HTMLDivElement>>(new Map())
     const lastScrollYRef = useRef(0)
     const scrollDirectionRef = useRef<"up" | "down">("down")
 
     const deferredSearch = useDeferredValue(filters.search)
+    const {
+        data: events,
+        loading,
+        error,
+    } = useDiscoverEvents({
+        limit: 24,
+        page: 1,
+        search: deferredSearch,
+        typeId: filters.selectedTypeId,
+        categoryId: filters.selectedCategoryId,
+        dateFilter: filters.selectedDateFilter,
+        sort: filters.sort,
+    })
+    const { data: categories } = useDiscoverCategories()
+    const { data: eventTypes } = useDiscoverEventTypes()
 
     useEffect(() => {
         const nextSearch = searchParams.get("search") ?? ""
@@ -67,94 +75,6 @@ function Events() {
             return { ...currentFilters, search: nextSearch }
         })
     }, [searchParams])
-
-    useEffect(() => {
-        let ignore = false
-
-        async function loadEventTypes() {
-            try {
-                const response = await fetchDiscoverEventTypes()
-                if (!ignore) {
-                    setEventTypes(response)
-                }
-            } catch {
-                if (!ignore) {
-                    setEventTypes([])
-                }
-            }
-        }
-
-        loadEventTypes()
-
-        return () => {
-            ignore = true
-        }
-    }, [])
-
-    useEffect(() => {
-        let ignore = false
-
-        async function loadCategories() {
-            try {
-                const response = await fetchDiscoverCategories()
-                if (!ignore) {
-                    setCategories(response)
-                }
-            } catch {
-                if (!ignore) {
-                    setCategories([])
-                }
-            }
-        }
-
-        loadCategories()
-
-        return () => {
-            ignore = true
-        }
-    }, [])
-
-    useEffect(() => {
-        let ignore = false
-
-        async function loadEvents() {
-            setLoading(true)
-            setError(null)
-
-            try {
-                const response = await fetchDiscoverEvents({
-                    limit: 24,
-                    page: 1,
-                    search: deferredSearch,
-                    typeId: filters.selectedTypeId,
-                    categoryId: filters.selectedCategoryId,
-                    dateFilter: filters.selectedDateFilter,
-                    sort: filters.sort,
-                })
-
-                if (!ignore) {
-                    startTransition(() => {
-                        setEvents(response)
-                    })
-                }
-            } catch (nextError) {
-                if (!ignore) {
-                    setError(nextError instanceof Error ? nextError.message : "Failed to load events")
-                    setEvents([])
-                }
-            } finally {
-                if (!ignore) {
-                    setLoading(false)
-                }
-            }
-        }
-
-        loadEvents()
-
-        return () => {
-            ignore = true
-        }
-    }, [deferredSearch, filters.selectedCategoryId, filters.selectedDateFilter, filters.selectedTypeId, filters.sort])
 
     const visibleEvents = events
 


### PR DESCRIPTION
## Summary

- Added a shared async list lifecycle hook with loading, error, empty fallback, stale-response, and unmount protection.
- Added event/discover domain hooks under `src/hooks/event` for discover events, event metadata, nearby events, and landing upcoming events.
- Refactored `Events`, `NearMeModal`, and `FeaturedEventsSection` to consume domain hooks instead of defining inline API loaders.
- Added separate hook tests for success, error fallback, stale responses, unmount behavior, idle nearby state, and landing query shape.

## Validation

- `npm run test` passed: 30 tests
- `npm run lint:fix` passed
- `npm run build` passed

## Notes

Backend request contracts were preserved; no frontend business logic was added.