### PR TITLE
[codex] Refactor event RSVP card

### DIFF
--- a/src/components/event/EventHostCard.tsx
+++ b/src/components/event/EventHostCard.tsx
@@ -15,7 +15,7 @@ export default function EventHostCard({ event }: EventHostCardProps) {
     return (
         <WindowCard
             data-testid={testIds.event.hostCard}
-            className="overflow-hidden bg-violet-light motion-safe:animate-in motion-safe:fade-in-0 motion-safe:slide-in-from-bottom-4 motion-safe:duration-500"
+            className="overflow-hidden motion-safe:animate-in motion-safe:fade-in-0 motion-safe:slide-in-from-bottom-4 motion-safe:duration-500"
         >
             <div className="p-5 md:p-6">
                 <EventSectionHeading label="Hosted by" />

--- a/src/components/event/EventRsvpCard.tsx
+++ b/src/components/event/EventRsvpCard.tsx
@@ -1,41 +1,293 @@
-import { useState } from "react"
+import {
+    createContext,
+    useCallback,
+    useContext,
+    useMemo,
+    useState,
+    type ComponentProps,
+    type PropsWithChildren,
+} from "react"
 import { Link, useNavigate } from "react-router"
+import { Check, HelpCircle, Minus, Plus } from "lucide-react"
 import { toast } from "sonner"
 import type { Event } from "@/types/Event"
 import WindowCard from "@/components/ui/window-card"
 import BrutalButton from "@/components/ui/brutal-button"
 import {
     createEventRsvp,
+    updateEventRsvp,
     type EventRsvpStatus,
 } from "@/requests/event"
 import {
-    formatEventDateDetailed,
     formatEventFee,
-    getEventCapacityLabel,
+    getEventCapacityDisplay,
 } from "@/components/event/event-utils"
 import { isLoggedIn } from "@/helpers/auth"
 import { testIds } from "@/testIds"
+import { cn } from "@/lib/utils"
 
-type EventRsvpCardProps = {
+type EventRsvpCardProps = PropsWithChildren & Omit<ComponentProps<typeof WindowCard>, "children"> & {
     event: Event
 }
 
-export default function EventRsvpCard({ event }: EventRsvpCardProps) {
+type RsvpChoiceStatus = Extract<EventRsvpStatus, "confirmed" | "maybe">
+
+type EventRsvpCardContextValue = {
+    event: Event
+    selectedStatus: EventRsvpStatus | null
+    submittingStatus: EventRsvpStatus | null
+    loggedIn: boolean
+    additionalGuests: number
+    onRsvp: (status: EventRsvpStatus) => void
+    onAdjustAdditionalGuests: (nextValue: number) => void
+}
+
+type RsvpChoiceButtonProps = {
+    status: RsvpChoiceStatus
+    selectedStatus: EventRsvpStatus | null
+    submittingStatus: EventRsvpStatus | null
+    disabled: boolean
+    onSelect: (status: EventRsvpStatus) => void
+}
+
+type GuestStepperControlProps = {
+    value: number
+    onChange: (nextValue: number) => void
+}
+
+const EventRsvpCardContext = createContext<EventRsvpCardContextValue | undefined>(undefined)
+
+function useEventRsvpCardContext() {
+    const context = useContext(EventRsvpCardContext)
+
+    if (!context) {
+        throw new Error("useEventRsvpCardContext must be within an EventRsvpCard")
+    }
+
+    return context
+}
+
+function PriceCapacitySection() {
+    const { event } = useEventRsvpCardContext()
+    const capacity = getEventCapacityDisplay(event)
+    const progressPercent = capacity.progressPercent ?? 0
+
+    return (
+        <>
+            <p className="whitespace-nowrap text-center font-heading text-5xl font-black uppercase leading-none text-foreground md:text-6xl">
+                {formatEventFee(event)}
+            </p>
+
+            <div className="mt-5">
+                <div className="flex items-end justify-between gap-4">
+                    <p className="font-heading text-lg font-black uppercase leading-tight">{capacity.label}</p>
+                    <p className="text-right font-mono text-[10px] font-bold uppercase tracking-[0.14em] text-foreground/65">
+                        {capacity.helper}
+                    </p>
+                </div>
+                <div
+                    className="mt-3 h-4 overflow-hidden border-[3px] border-border bg-card shadow-[3px_3px_0_0_hsl(var(--border))]"
+                    aria-label={capacity.label}
+                >
+                    <div
+                        className={cn(
+                            "h-full bg-mint transition-[width] duration-300",
+                            capacity.progressPercent === null && "bg-[repeating-linear-gradient(135deg,#B8F2C8_0,#B8F2C8_6px,#fff_6px,#fff_12px)]",
+                        )}
+                        style={{ width: `${progressPercent}%` }}
+                    />
+                </div>
+            </div>
+        </>
+    )
+}
+
+function RsvpChoiceButton({
+    status,
+    selectedStatus,
+    submittingStatus,
+    disabled,
+    onSelect,
+}: Readonly<RsvpChoiceButtonProps>) {
+    const isGoing = status === "confirmed"
+    const isSelected = selectedStatus === status
+    const Icon = isGoing ? Check : HelpCircle
+    const label = isGoing ? "GOING" : "MAYBE"
+    const savingLabel = submittingStatus === status ? "SAVING" : label
+    let tone: ComponentProps<typeof BrutalButton>["tone"] = "cream"
+
+    if (isSelected) {
+        tone = isGoing ? "mint" : "violet"
+    }
+
+    return (
+        <BrutalButton
+            tone={tone}
+            className={cn(
+                "min-w-0 justify-center gap-2 px-3 text-xs",
+                isSelected && "shadow-none translate-x-1 translate-y-1",
+            )}
+            onClick={() => onSelect(status)}
+            disabled={disabled}
+        >
+            <Icon className="h-4 w-4 shrink-0 stroke-[3]" aria-hidden="true" />
+            {savingLabel}
+        </BrutalButton>
+    )
+}
+
+function GuestStepperControl({ value, onChange }: Readonly<GuestStepperControlProps>) {
+    return (
+        <div className="flex items-center justify-between gap-4">
+            <span className="font-mono text-[11px] font-bold uppercase tracking-[0.16em] text-foreground/70">
+                Additional guests
+            </span>
+            <div className="flex shrink-0 items-center">
+                <button
+                    type="button"
+                    className="flex h-11 w-11 items-center justify-center border-[3px] border-border bg-card transition hover:bg-mint disabled:cursor-not-allowed disabled:opacity-50"
+                    onClick={() => onChange(value - 1)}
+                    disabled={value === 0}
+                    aria-label="Remove additional guest"
+                >
+                    <Minus className="h-4 w-4 stroke-[4]" aria-hidden="true" />
+                </button>
+                <span className="flex h-11 w-12 items-center justify-center border-y-[3px] border-border bg-card font-display text-xl font-extrabold">
+                    {value}
+                </span>
+                <button
+                    type="button"
+                    className="flex h-11 w-11 items-center justify-center border-[3px] border-border bg-card transition hover:bg-mint"
+                    onClick={() => onChange(value + 1)}
+                    aria-label="Add additional guest"
+                >
+                    <Plus className="h-4 w-4 stroke-[4]" aria-hidden="true" />
+                </button>
+            </div>
+        </div>
+    )
+}
+
+function AuthActionLinks() {
+    return (
+        <div className="mt-4 grid gap-3">
+            <BrutalButton asChild tone="mint" className="w-full">
+                <Link to="/login" data-testid={testIds.event.rsvpLoginLink}>Log in to join</Link>
+            </BrutalButton>
+            <BrutalButton asChild tone="cream" className="w-full">
+                <Link to="/register">Create an account</Link>
+            </BrutalButton>
+        </div>
+    )
+}
+
+function GuestStepper() {
+    const { additionalGuests, onAdjustAdditionalGuests } = useEventRsvpCardContext()
+
+    return <GuestStepperControl value={additionalGuests} onChange={onAdjustAdditionalGuests} />
+}
+
+function CancelButton() {
+    const { loggedIn, selectedStatus, submittingStatus, onRsvp } = useEventRsvpCardContext()
+
+    if (loggedIn) {
+        return (
+            <button
+                type="button"
+                className={cn(
+                    "w-full text-center text-sm font-black underline decoration-[2px] underline-offset-4 transition hover:text-violet",
+                    selectedStatus === "canceled" && "text-violet",
+                )}
+                onClick={() => onRsvp("canceled")}
+                disabled={submittingStatus !== null}
+            >
+                {submittingStatus === "canceled" ? "Saving..." : "Can't Go"}
+            </button>
+        )
+    }
+
+    return null
+}
+
+function ParticipationPanel() {
+    const {
+        loggedIn,
+        selectedStatus,
+        submittingStatus,
+        onRsvp,
+    } = useEventRsvpCardContext()
+    const rsvpDisabled = loggedIn ? submittingStatus !== null : true
+    const disabledContentClassName = loggedIn ? undefined : "pointer-events-none opacity-70"
+    const authActionLinks = loggedIn ? null : <AuthActionLinks />
+
+    return (
+        <div className="relative mt-6 overflow-hidden border-y-[3px] border-border py-4">
+            <div className={cn("space-y-4", disabledContentClassName)}>
+                <div className="grid grid-cols-2 gap-3">
+                    {(["confirmed", "maybe"] as const).map((status) => (
+                        <RsvpChoiceButton
+                            key={status}
+                            status={status}
+                            selectedStatus={selectedStatus}
+                            submittingStatus={submittingStatus}
+                            disabled={rsvpDisabled}
+                            onSelect={onRsvp}
+                        />
+                    ))}
+                </div>
+
+                {loggedIn ? (
+                    <>
+                        <GuestStepper />
+                        <CancelButton />
+                    </>
+                ) : null}
+            </div>
+
+            {authActionLinks}
+        </div>
+    )
+}
+
+function EventRsvpCardRoot({
+    event,
+    children,
+    titlebarLabel = "JOIN THIS EVENT",
+    className,
+    ...props
+}: Readonly<EventRsvpCardProps>) {
     const navigate = useNavigate()
     const loggedIn = isLoggedIn()
-    const [additionalGuests, setAdditionalGuests] = useState(0)
+    const initialRsvp = event.currentUserRsvp
+    const initialRsvpId = initialRsvp?.id ?? initialRsvp?._id
+    const [additionalGuests, setAdditionalGuests] = useState(initialRsvp?.additionalGuests ?? 0)
+    const [selectedStatus, setSelectedStatus] = useState<EventRsvpStatus | null>(
+        initialRsvp?.status ?? null,
+    )
+    const [rsvpId, setRsvpId] = useState(initialRsvpId)
     const [submittingStatus, setSubmittingStatus] = useState<EventRsvpStatus | null>(null)
 
-    async function handleRsvp(status: EventRsvpStatus) {
+    const handleRsvp = useCallback(async (status: EventRsvpStatus) => {
         setSubmittingStatus(status)
 
         try {
-            await createEventRsvp({
-                eventId: event._id,
-                status,
-                additionalGuests,
-            })
-            toast(status === "confirmed" ? "You are on the guest list." : "Marked as maybe.")
+            const response = rsvpId
+                ? await updateEventRsvp(rsvpId, { status, additionalGuests })
+                : await createEventRsvp({
+                    eventId: event._id,
+                    status,
+                    additionalGuests,
+                })
+            setRsvpId(response.id ?? response._id ?? rsvpId)
+            setSelectedStatus(status)
+
+            if (status === "confirmed") {
+                toast("You are on the guest list.")
+            } else if (status === "maybe") {
+                toast("Marked as maybe.")
+            } else {
+                toast("RSVP canceled.")
+            }
         } catch (error) {
             const message = error instanceof Error ? error.message : "Could not update RSVP"
 
@@ -48,93 +300,59 @@ export default function EventRsvpCard({ event }: EventRsvpCardProps) {
         } finally {
             setSubmittingStatus(null)
         }
-    }
+    }, [additionalGuests, event._id, navigate, rsvpId])
 
-    async function handleShare() {
-        try {
-            await navigator.clipboard.writeText(window.location.href)
-            toast("Event link copied.")
-        } catch {
-            toast("Could not copy the link.")
-        }
-    }
+    const adjustAdditionalGuests = useCallback((nextValue: number) => {
+        setAdditionalGuests(Math.min(10, Math.max(0, nextValue)))
+    }, [])
+    const contextValue = useMemo<EventRsvpCardContextValue>(() => ({
+        event,
+        loggedIn,
+        selectedStatus,
+        submittingStatus,
+        additionalGuests,
+        onRsvp: handleRsvp,
+        onAdjustAdditionalGuests: adjustAdditionalGuests,
+    }), [
+        additionalGuests,
+        adjustAdditionalGuests,
+        event,
+        handleRsvp,
+        loggedIn,
+        selectedStatus,
+        submittingStatus,
+    ])
 
     return (
         <WindowCard
             data-testid={testIds.event.rsvpCard}
-            titlebarLabel="Join this event"
-            className="motion-safe:animate-in motion-safe:fade-in-0 motion-safe:slide-in-from-bottom-4 motion-safe:duration-500"
+            titlebarLabel={titlebarLabel}
+            className={cn(
+                "rounded-none motion-safe:animate-in motion-safe:fade-in-0 motion-safe:slide-in-from-bottom-4 motion-safe:duration-500",
+                className,
+            )}
+            {...props}
         >
-            <div className="p-5 md:p-6">
-                <p className="font-display text-4xl font-extrabold tracking-[-0.06em]">{formatEventFee(event)}</p>
-                <p className="mt-3 text-sm font-semibold text-foreground/75">{getEventCapacityLabel(event)}</p>
-                <p className="mt-2 text-sm leading-6 text-foreground/65">{formatEventDateDetailed(event.date)}</p>
-
-                {loggedIn ? (
-                    <>
-                        <div className="mt-5 flex items-center justify-between gap-4 border-y-2 border-border py-4">
-                            <span className="font-mono text-[11px] font-bold uppercase tracking-[0.18em] text-foreground/65">
-                                Additional guests
-                            </span>
-                            <div className="flex items-center">
-                                <button
-                                    type="button"
-                                    className="flex h-10 w-10 items-center justify-center border-[2px] border-border bg-card text-xl font-bold"
-                                    onClick={() => setAdditionalGuests((value) => Math.max(0, value - 1))}
-                                >
-                                    -
-                                </button>
-                                <span className="flex h-10 w-11 items-center justify-center border-y-[2px] border-border bg-card font-display text-lg font-extrabold">
-                                    {additionalGuests}
-                                </span>
-                                <button
-                                    type="button"
-                                    className="flex h-10 w-10 items-center justify-center border-[2px] border-border bg-card text-xl font-bold"
-                                    onClick={() => setAdditionalGuests((value) => Math.min(10, value + 1))}
-                                >
-                                    +
-                                </button>
-                            </div>
-                        </div>
-
-                        <div className="mt-5 grid gap-3">
-                            <BrutalButton
-                                tone="mint"
-                                className="w-full"
-                                onClick={() => handleRsvp("confirmed")}
-                                disabled={submittingStatus !== null}
-                            >
-                                {submittingStatus === "confirmed" ? "Joining..." : "Attend event"}
-                            </BrutalButton>
-                            <BrutalButton
-                                tone="cream"
-                                className="w-full"
-                                onClick={() => handleRsvp("maybe")}
-                                disabled={submittingStatus !== null}
-                            >
-                                {submittingStatus === "maybe" ? "Saving..." : "Maybe later"}
-                            </BrutalButton>
-                        </div>
-                    </>
-                ) : (
-                    <div className="mt-5 grid gap-3">
-                        <BrutalButton asChild tone="mint" className="w-full">
-                            <Link to="/login" data-testid={testIds.event.rsvpLoginLink}>Log in to join</Link>
-                        </BrutalButton>
-                        <BrutalButton asChild tone="cream" className="w-full">
-                            <Link to="/register">Create an account</Link>
-                        </BrutalButton>
-                    </div>
-                )}
-
-                <button
-                    type="button"
-                    className="mt-5 w-full text-center text-sm font-bold text-violet underline underline-offset-4 transition hover:text-mint"
-                    onClick={handleShare}
-                >
-                    Share with friends
-                </button>
-            </div>
+            <EventRsvpCardContext.Provider value={contextValue}>
+                <div className="p-5 md:p-6">
+                    {children ?? (
+                        <>
+                            <PriceCapacitySection />
+                            <ParticipationPanel />
+                        </>
+                    )}
+                </div>
+            </EventRsvpCardContext.Provider>
         </WindowCard>
     )
 }
+
+const EventRsvpCard = Object.assign(EventRsvpCardRoot, {
+    PriceCapacity: PriceCapacitySection,
+    Participation: ParticipationPanel,
+    GuestStepper,
+    CancelButton,
+    AuthActions: AuthActionLinks,
+})
+
+export default EventRsvpCard

--- a/src/components/event/event-utils.ts
+++ b/src/components/event/event-utils.ts
@@ -39,10 +39,81 @@ export function formatEventFee(event: Pick<Event, "fee">) {
         return "Free"
     }
 
-    return new Intl.NumberFormat("en-GB", {
-        style: "currency",
-        currency,
+    const numberLabel = new Intl.NumberFormat("en-GB", {
+        maximumFractionDigits: Number.isInteger(amount) ? 0 : 2,
     }).format(amount)
+    const currencySymbol = new Intl.NumberFormat("en-US", {
+        currencyDisplay: "narrowSymbol",
+        currency,
+        style: "currency",
+    }).formatToParts(amount).find((part) => part.type === "currency")?.value ?? currency
+
+    return `${numberLabel}${currencySymbol}`
+}
+
+type EventCapacityDisplay = {
+    label: string
+    progressPercent: number | null
+    isLimited: boolean
+    helper: string
+}
+
+function clampPercent(value: number) {
+    return Math.min(100, Math.max(0, value))
+}
+
+export function getEventCapacityDisplay(
+    event: Pick<Event, "capacity" | "maxAttendees">,
+): EventCapacityDisplay {
+    const maxAttendees = event.maxAttendees
+
+    if (!maxAttendees || maxAttendees < 0) {
+        return {
+            label: "Unlimited spots",
+            progressPercent: null,
+            isLimited: false,
+            helper: "No event limit",
+        }
+    }
+
+    if (typeof event.capacity?.spotsLeft === "number") {
+        const spotsLeft = Math.max(0, event.capacity.spotsLeft)
+        const usedSpots = Math.max(0, maxAttendees - spotsLeft)
+
+        return {
+            label: `${spotsLeft} / ${maxAttendees} spots left`,
+            progressPercent: clampPercent((usedSpots / maxAttendees) * 100),
+            isLimited: true,
+            helper: "Live capacity",
+        }
+    }
+
+    if (typeof event.capacity?.confirmedAttendees === "number") {
+        const confirmedAttendees = Math.max(0, event.capacity.confirmedAttendees)
+
+        return {
+            label: `${confirmedAttendees} / ${maxAttendees} going`,
+            progressPercent: clampPercent((confirmedAttendees / maxAttendees) * 100),
+            isLimited: true,
+            helper: "Live attendance",
+        }
+    }
+
+    if (typeof event.capacity?.progressPercent === "number") {
+        return {
+            label: `${maxAttendees} total spots`,
+            progressPercent: clampPercent(event.capacity.progressPercent),
+            isLimited: true,
+            helper: "Live capacity",
+        }
+    }
+
+    return {
+        label: `${maxAttendees} total spots`,
+        progressPercent: null,
+        isLimited: true,
+        helper: "Spots left unavailable",
+    }
 }
 
 export function getEventCapacityLabel(event: Pick<Event, "maxAttendees">) {

--- a/src/components/ui/window-card.tsx
+++ b/src/components/ui/window-card.tsx
@@ -17,7 +17,7 @@ export default function WindowCard({
     return (
         <Card
             variant="raised"
-            className={cn("gap-0 overflow-hidden rounded-none bg-card py-0", className)}
+            className={cn("gap-0 overflow-hidden rounded-none bg-event-surface py-0", className)}
             {...props}
         >
             {titlebarLabel ? (

--- a/src/requests/event.ts
+++ b/src/requests/event.ts
@@ -4,7 +4,7 @@ import { makeRequest, normalizeApiDateValue } from '@/requests/utils';
 
 const eventCache = new Map<string, Promise<Event | null>>();
 
-export type EventRsvpStatus = "confirmed" | "maybe";
+export type EventRsvpStatus = "confirmed" | "maybe" | "canceled";
 
 type EventRsvpPayload = {
     eventId: string
@@ -12,7 +12,7 @@ type EventRsvpPayload = {
     additionalGuests?: number
 }
 
-type EventRsvp = {
+export type EventRsvp = {
     id?: string
     _id?: string
     status: string
@@ -64,6 +64,15 @@ export async function fetchEvent(id: string): Promise<Event | null> {
 export async function createEventRsvp(payload: EventRsvpPayload): Promise<EventRsvp> {
     const response = await makeRequest<{ success: boolean; data: EventRsvp }>(() =>
         axios.post("/event/attend", payload),
+        "rsvp",
+    )
+
+    return response.data
+}
+
+export async function updateEventRsvp(rsvpId: string, payload: Omit<EventRsvpPayload, "eventId">): Promise<EventRsvp> {
+    const response = await makeRequest<{ success: boolean; data: EventRsvp }>(() =>
+        axios.put(`/rsvp/${rsvpId}`, payload),
         "rsvp",
     )
 

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -11,6 +11,7 @@
   --yellow: 47 100% 62%;
   --coral: 0 84.2% 60.2%;
   --cream: 43 100% 98%;
+  --event-surface: 42 100% 95%;
   --black: 0 0% 0%;
   --white-card: 0 0% 100%;
 }

--- a/src/types/Event.ts
+++ b/src/types/Event.ts
@@ -19,6 +19,18 @@ export type Event = {
     author: Pick<User, "id" | "username" | "avatarUrl">;
     type: Eventtype;
     maxAttendees?: number;
+    capacity?: {
+        maxAttendees?: number;
+        spotsLeft?: number;
+        confirmedAttendees?: number;
+        progressPercent?: number;
+    };
+    currentUserRsvp?: {
+        id?: string;
+        _id?: string;
+        status: "confirmed" | "maybe" | "canceled";
+        additionalGuests?: number;
+    };
     fee?: {
         amount: number;
         currency: string;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -48,6 +48,9 @@ export default {
                 yellow: 'hsl(var(--yellow))',
                 coral: 'hsl(var(--coral))',
                 cream: 'hsl(var(--cream))',
+                event: {
+                    surface: 'hsl(var(--event-surface))',
+                },
                 main: {
                     DEFAULT: 'hsl(var(--main))',
                     foreground: 'hsl(var(--main-foreground))'


### PR DESCRIPTION
## Summary

Refactors the event RSVP card into a compound component with context-backed subcomponents, matching the composition pattern used by `UserCard` while preserving the existing default render path.

Also keeps the RSVP UI state in one place, supports updating existing RSVPs, exposes canceled RSVP handling, and uses backend-provided capacity fields for the event capacity display.

## Impact

- Existing `<EventRsvpCard event={event} />` usage continues to work.
- The card can now be composed with `EventRsvpCard.PriceCapacity`, `EventRsvpCard.Participation`, `EventRsvpCard.GuestStepper`, and related subcomponents.
- Current user RSVP state initializes from `event.currentUserRsvp` when present and creates a new RSVP when absent.

## Validation

- `npm run lint:fix`
- `npm run build`